### PR TITLE
fix: checkout 探测补充 ~/deepseek-harness 候选路径

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ cd "$ROOT"
 # DSH_CHECKOUT 探测：环境变量 → 常见路径（home 下 dsh-harness）
 CHECKOUT="\${DSH_CHECKOUT:-}"
 if [ -z "$CHECKOUT" ]; then
-  for candidate in "\$HOME/dsh-harness" "\$HOME/dsh" "\$HOME/.dsh/dsh-harness"; do
+  for candidate in "\$HOME/dsh-harness" "\$HOME/dsh" "\$HOME/.dsh/dsh-harness" "\$HOME/deepseek-harness"; do
     if [ -d "\$candidate/packages" ]; then CHECKOUT="\$candidate"; break; fi
   done
 fi
@@ -2712,6 +2712,7 @@ export function apply(ctx: AppContext, config: Config): void {
       join(homedir(), 'dsh-harness'),
       join(homedir(), 'dsh'),
       join(homedir(), '.dsh', 'dsh-harness'),
+      join(homedir(), 'deepseek-harness'),
     ]
     for (const c of candidates) {
       if (existsSync(join(c, 'packages'))) return c


### PR DESCRIPTION
## 问题detectCheckout() 与脚手架 build.sh 模板的常见路径探测缺省了 \~/deepseek-harness\ —— 实际部署中最常见的 DSH 源码 checkout 目录名（如插件清单中大量入口指向 \C:/Users/<user>/deepseek-harness/packages/...\）。当 DSH_CHECKOUT 未设置时，自检/构建链第一步即失败（实测：\dev_self_test\ 报 [FAIL] checkout 探测 — 无 DSH_CHECKOUT）。## 修复- \detectCheckout()\ 候选列表追加 \join(homedir(), 'deepseek-harness')\- 脚手架生成的 build.sh 探测列表同步追加 \\\\C:\Users\14040/deepseek-harness\## 验证- 补丁热重载后 \dev_self_test\ 8/8 全 PASS（此前 0/1，卡在 checkout 探测）- 探测到 \C:/Users/14040/deepseek-harness\（含 packages/ + vendor/ + tsc）并完成测试插件构建注入全链路## 变更规模1 文件 +2/-1（两处探测列表各加一个候选路径）