### PR TITLE
fix(patch): 去重不再误删顶层 config 块（缩进子条目分桶 + 保留最后一条）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@
 > **版本以 git tag 为准**：已发布 v0.3.1 / v0.3.3（GitHub Releases 资产）；未打 tag 的
 > 小节为开发史（其内容随下一个发布一并交付）。
 
+## [0.3.4] — 2026-08-16
+
+### 修复（patch 去重误删顶层 config 块——8/15 实测事故根治）
+
+- **extractPatchBlocks 缩进误判根治**：`- id:` 正则无锚点，insert 块内缩进的子条目被当成
+  顶层条目，与同 id 的顶层 config 块（如 dsh-vision 的 baseURL/model）判重后把后者删掉——
+  实测事故：web profile 的 dsh-vision 后端配置被 dev_fix_patch 吃掉，view_image 回落到智谱
+  默认端点，商汤 key 打到智谱报 401「令牌已过期或验证不正确」。修复：顶层条目只认第 0 列；
+  缩进 `- id:`（insert 子条目 / group config 子条目）一律按嵌套条目分桶，与顶层去重互不干扰
+- **去重保留语义对齐**：writePatch / dev_fix_patch / fix-patch.mjs 注释声称「保留最后一条」
+  但代码实际保留第一条——统一改为倒序保留最后一条（与 loader 顺序覆盖语义一致）
+- **顶格注释保留**：dev_fix_patch 重写时不再丢弃文件头注释
+
 ## [0.3.3] — 2026-08-15（已发布，git tag v0.3.3）
 
 ### 更新（高性能引导升级为 P1-P23 完整认知）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-external/dsh-super-injector",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "超级模组注入器：运行时注入任意本地 DSH 插件包（junction 链接 + loader.create，不碰 patch/package.json/不重启），热重载全家桶 + 开发侧挂区一键转正 + 一键卸载 + 路由自愈 + 插件管理 UI（设置页：列表/卸载/拖入内化），清单持久化重启自动恢复——DSH 生态的 BepInEx 式模组注入入口",
   "private": true,
   "type": "module",

--- a/scripts/fix-patch.mjs
+++ b/scripts/fix-patch.mjs
@@ -9,7 +9,7 @@
  *
  * 行为：
  *  1. 扫描所有 profile 的 cordis.patch.yml（或 --profile 指定一个）；
- *  2. 按 entry id 去重（同 id 保留最后一条；注释保留；顶层 [] 清理）；
+ *  2. 按顶层/嵌套条目分桶去重（同 id 保留最后一条；注释保留；顶层 [] 清理）；
  *  3. 修复前自动备份为 cordis.patch.yml.bak-<时间戳>；
  *  4. 输出每处修复（哪个 profile、哪个 id 重复、删了几条）。
  *
@@ -26,19 +26,36 @@ const args = process.argv.slice(2)
 const onlyProfile = args.includes('--profile') ? args[args.indexOf('--profile') + 1] : null
 const checkOnly = args.includes('--check')
 
-/** 切分 patch 内容为条目块（`- id:` 及其子行 + 前置注释），返回块列表与杂散行。 */
+/** 切分 patch 内容为条目块（`- id:` 及其子行 + 前置注释），返回块列表与杂散行。
+ * 顶层条目只认第 0 列的 `- id:`；缩进的 `- id:`（insert 子条目 / group config
+ * 子条目）打 fromInsert 标记，去重时与顶层分桶——避免把同 id 的顶层 config 块
+ * （如 dsh-vision 的 baseURL/model）误当重复删掉（2026-08-15 事故）。 */
 function extractBlocks(content) {
   const lines = content.split('\n')
   const blocks = []
   let current = null
   for (const line of lines) {
-    const idMatch = /^\s*- id:\s*([^\s#]+)/.exec(line)
-    if (idMatch) {
+    const trimmed = line.trim()
+    if (trimmed === '') {
+      if (current) current.text += '\n' + line
+      continue
+    }
+    const atCol0 = line[0] !== ' ' && line[0] !== '\t'
+    const idMatch = /^-\s+id:\s*([^\s#]+)/.exec(line)
+    if (atCol0 && idMatch) {
       if (current) blocks.push(current)
-      current = { id: idMatch[1], text: line }
+      current = { id: idMatch[1], fromInsert: false, text: line }
+    } else if (idMatch) {
+      // 缩进 `- id:`：insert/group 的嵌套子条目，去重时与顶层分桶
+      if (current) blocks.push(current)
+      current = { id: idMatch[1], fromInsert: true, text: line }
+    } else if (atCol0) {
+      if (current) blocks.push(current)
+      current = null
+      if (!/^\s*\[\]\s*$/.test(trimmed)) blocks.push({ id: undefined, text: line })
     } else if (current) {
       current.text += '\n' + line
-    } else if (line.trim() !== '' && !/^\s*#/.test(line) && !/^\s*\[\]\s*$/.test(line)) {
+    } else if (trimmed !== '' && !/^\s*#/.test(trimmed)) {
       blocks.push({ id: undefined, text: line })
     }
   }
@@ -46,23 +63,36 @@ function extractBlocks(content) {
   return blocks
 }
 
-/** 去重：同 id 保留最后一条；返回 {text, removed:[{id, count}]}。 */
+/** 去重：顶层与嵌套分桶、同 id 保留最后一条（与 loader 顺序覆盖语义一致）；
+ * 返回 {text, removed:[{id, fromInsert, count}]}。 */
 function dedupe(content) {
   const blocks = extractBlocks(content)
-  const seen = new Set()
-  const removed = []
-  const kept = []
+  const keyOf = (b) => (b.fromInsert ? 'nested:' : 'top:') + b.id
+  const counts = new Map()
   for (const b of blocks) {
-    if (b.id) {
-      if (seen.has(b.id)) {
-        const rec = removed.find((r) => r.id === b.id)
-        if (rec) rec.count += 1
-        else removed.push({ id: b.id, count: 1 })
-        continue
-      }
-      seen.add(b.id)
+    if (!b.id) continue
+    const k = keyOf(b)
+    counts.set(k, (counts.get(k) ?? 0) + 1)
+  }
+  const removed = []
+  for (const [k, n] of counts) {
+    if (n > 1) {
+      const sep = k.indexOf(':')
+      removed.push({ id: k.slice(sep + 1), fromInsert: k.startsWith('nested:'), count: n - 1 })
     }
-    kept.push(b.text)
+  }
+  if (removed.length === 0) return { text: content, removed }
+  // 保留最后一条：倒序遍历，从尾部看首次出现者保留
+  const seen = new Set()
+  const kept = []
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    const b = blocks[i]
+    if (b.id) {
+      const k = keyOf(b)
+      if (seen.has(k)) continue
+      seen.add(k)
+    }
+    kept.unshift(b.text)
   }
   return { text: kept.join('\n'), removed }
 }
@@ -122,7 +152,7 @@ function main() {
     }
     fixedAny = true
     for (const rec of r.removed) {
-      console.log(`[${profile}] 修复：id "${rec.id}" 重复，删除 ${rec.count} 条（保留最后一条）`)
+      console.log(`[${profile}] 修复：${rec.fromInsert ? '嵌套条目 ' : ''}id "${rec.id}" 重复，删除 ${rec.count} 条（保留最后一条）`)
     }
     if (!checkOnly) console.log(`[${profile}] 已重写（原文件备份为 ${patchFile}.bak-<时间戳>）`)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -739,14 +739,20 @@ export function apply(ctx: AppContext, config: Config): void {
       // 2. 提取现有内容里所有条目块（含注释），按 id 归组
       const blocks = extractPatchBlocks(content)
       const existing = new Set<string>()
+      // 顶层与嵌套（insert 子条目 / group config）分桶去重，保留最后一条（与
+      // loader 顺序覆盖语义一致）；existing 收集全部 id 供幂等判断
+      const keyOf = (b: { id?: string; fromInsert?: boolean }) => (b.fromInsert ? 'nested:' : 'top:') + b.id
+      const seen = new Set<string>()
       const kept: string[] = []
-      for (const b of blocks) {
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const b = blocks[i]
         if (b.id) {
-          // 同 id 重复：只保留最后一条（后续同名覆盖先前的）
-          if (existing.has(b.id)) continue
           existing.add(b.id)
+          const k = keyOf(b)
+          if (seen.has(k)) continue
+          seen.add(k)
         }
-        kept.push(b.text)
+        kept.unshift(b.text)
       }
       // 3. 幂等：appendIds 全部已存在 → 不写入
       if (appendIds.length > 0 && appendIds.every((id) => existing.has(id))) {
@@ -763,31 +769,38 @@ export function apply(ctx: AppContext, config: Config): void {
 
   /** 把 patch 内容切分为"条目块"（`- id:` 及其缩进子行 + 前置注释行）。
    * 每块文本保留行尾换行，块间 join 不粘连；顶格注释单独成块（不并入前一条目，
-   * 否则重写时注释会与下一条目粘连成一行、后续 `disabled: true` 等错挂条目）。 */
-  function extractPatchBlocks(content: string): Array<{ id?: string; text: string }> {
+   * 否则重写时注释会与下一条目粘连成一行、后续 `disabled: true` 等错挂条目）。
+   * 顶层条目只认第 0 列的 `- id:`；缩进的 `- id:`（insert 子条目 / group config
+   * 子条目）打 fromInsert 标记，去重时与顶层分桶——避免把同 id 的顶层 config 块
+   * （如 dsh-vision 的 baseURL/model）误当重复删掉（2026-08-15 事故）。 */
+  function extractPatchBlocks(content: string): Array<{ id?: string; fromInsert?: boolean; text: string }> {
     const lines = content.split('\n')
-    const blocks: Array<{ id?: string; text: string }> = []
-    let current: { id?: string; text: string } | null = null
+    const blocks: Array<{ id?: string; fromInsert?: boolean; text: string }> = []
+    let current: { id?: string; fromInsert?: boolean; text: string } | null = null
     for (const line of lines) {
-      const idMatch = /^\s*- id:\s*([^\s#]+)/.exec(line)
-      if (idMatch) {
+      const trimmed = line.trim()
+      if (trimmed === '') {
+        if (current) current.text += line + '\n'
+        continue
+      }
+      const atCol0 = line[0] !== ' ' && line[0] !== '\t'
+      const idMatch = /^-\s+id:\s*([^\s#]+)/.exec(line)
+      if (atCol0 && idMatch) {
         if (current) blocks.push(current)
-        current = { id: idMatch[1], text: line + '\n' }
+        current = { id: idMatch[1], fromInsert: false, text: line + '\n' }
+      } else if (idMatch) {
+        // 缩进 `- id:`：insert/group 的嵌套子条目，去重时与顶层分桶
+        if (current) blocks.push(current)
+        current = { id: idMatch[1], fromInsert: true, text: line + '\n' }
+      } else if (atCol0) {
+        // 顶格注释/杂散行：结束当前块，单独成块保留（防止与下一条目粘连）
+        if (current) blocks.push(current)
+        current = null
+        if (!/^\s*\[\]\s*$/.test(trimmed)) blocks.push({ text: line + '\n' })
       } else if (current) {
-        if (/^\s/.test(line) || line.trim() === '') {
-          // 条目缩进子行或空行：留在当前块
-          current.text += line + '\n'
-        } else {
-          // 顶格注释/杂散行：结束当前块，单独成块保留（防止与下一条目粘连）
-          blocks.push(current)
-          current = null
-          blocks.push({ text: line + '\n' })
-        }
-      } else if (line.trim() !== '' && !/^\s*#/.test(line) && !/^\s*\[\]\s*$/.test(line)) {
-        // 非注释、非空、非条目的杂散行：保留原样（如 - insert: 包裹行）
-        blocks.push({ text: line + '\n' })
-      } else if (line.trim() !== '' && !/^\s*\[\]\s*$/.test(line)) {
-        // 顶格注释单独成块
+        // 条目缩进子行：留在当前块
+        current.text += line + '\n'
+      } else {
         blocks.push({ text: line + '\n' })
       }
     }
@@ -2537,7 +2550,7 @@ export function apply(ctx: AppContext, config: Config): void {
 
   safeRegister(defineTool({
     name: 'dev_fix_patch',
-    description: 'profile patch 修复：扫描 ~/.dsh/profiles/*/cordis.patch.yml，按 entry id 去重（同 id 保留最后一条，备份原文件）——修复 "duplicate loader entry id" 启动崩溃（手动 patch 两次/重复安装造成）。--check 只查不写',
+    description: 'profile patch 修复：扫描 ~/.dsh/profiles/*/cordis.patch.yml，顶层与嵌套条目（insert 子条目/group config）分桶去重（同 id 保留最后一条，备份原文件）——修复 "duplicate loader entry id" 启动崩溃（手动 patch 两次/重复安装造成）。--check 只查不写',
     parameters: {
       profile: { type: 'string', description: '只修指定 profile（缺省全部）' },
       check: { type: 'boolean', description: '只检查不写入' },
@@ -2562,29 +2575,42 @@ export function apply(ctx: AppContext, config: Config): void {
         let content = ''
         try { content = readFileSync(patchFile, 'utf8') } catch { out.push(`[${profile}] 读取失败（跳过）`); continue }
         const blocks = extractPatchBlocks(content)
-        const seen = new Set<string>()
-        const kept: string[] = []
-        const dup: Array<{ id: string; count: number }> = []
+        // 顶层与嵌套（insert 子条目 / group config）分桶去重：防止同 id 的顶层
+        // config 块被 insert 子条目误判为重复而删掉（2026-08-15 事故）
+        const keyOf = (b: { id?: string; fromInsert?: boolean }) => (b.fromInsert ? 'nested:' : 'top:') + b.id
+        const counts = new Map<string, number>()
         for (const b of blocks) {
-          if (b.id) {
-            if (seen.has(b.id)) {
-              const rec = dup.find((r) => r.id === b.id)
-              if (rec) rec.count += 1
-              else dup.push({ id: b.id, count: 1 })
-              continue
-            }
-            seen.add(b.id)
+          if (!b.id) continue
+          const k = keyOf(b)
+          counts.set(k, (counts.get(k) ?? 0) + 1)
+        }
+        const dup: Array<{ id: string; fromInsert: boolean; count: number }> = []
+        for (const [k, n] of counts) {
+          if (n > 1) {
+            const sep = k.indexOf(':')
+            dup.push({ id: k.slice(sep + 1), fromInsert: k.startsWith('nested:'), count: n - 1 })
           }
-          kept.push(b.text)
         }
         if (!dup.length) { out.push(`[${profile}] 健康：无重复 id`); continue }
         fixedAny = true
-        for (const rec of dup) out.push(`[${profile}] 修复：id "${rec.id}" 重复，删除 ${rec.count} 条（保留最后一条）`)
+        for (const rec of dup) out.push(`[${profile}] 修复：${rec.fromInsert ? '嵌套条目 ' : ''}id "${rec.id}" 重复，删除 ${rec.count} 条（保留最后一条）`)
         if (args.check) continue
         const bak = patchFile + '.bak-' + Date.now()
         try {
           renameSync(patchFile, bak)
-          writeFileSync(patchFile, kept.join('\n').replace(/\s*$/, '') + '\n', 'utf8')
+          // 保留最后一条（与 loader 顺序覆盖语义一致）：倒序保留首次出现
+          const seen = new Set<string>()
+          const kept: string[] = []
+          for (let i = blocks.length - 1; i >= 0; i--) {
+            const b = blocks[i]
+            if (b.id) {
+              const k = keyOf(b)
+              if (seen.has(k)) continue
+              seen.add(k)
+            }
+            kept.unshift(b.text)
+          }
+          writeFileSync(patchFile, kept.join('').replace(/\s*$/, '') + '\n', 'utf8')
           out.push(`[${profile}] 已重写（备份: ${bak}）`)
         } catch (e) {
           out.push(`[${profile}] 写入失败: ${String(e instanceof Error ? e.message : e)}`)


### PR DESCRIPTION
## 背景（8/15 实测事故）

web profile 的 `cordis.patch.yml` 中 dsh-vision 的顶层 config 块（baseURL/model/maxTokens）被 `dev_fix_patch` 误删：

- `extractPatchBlocks` 的正则 `/^\s*- id:/ ` 无锚点，**insert 块内缩进的子条目**被当成顶层条目
- 它与同 id 的**顶层 config 块**判重后把后者删掉（保留第一条、丢后面的）
- 后果：dsh-vision 回落智谱默认端点，商汤 key 打到智谱报 401「令牌已过期或验证不正确」

## 改动

1. **extractPatchBlocks**：顶层条目只认第 0 列的 `- id:`；缩进的 `- id:`（insert 子条目 / group config 子条目）打 `fromInsert` 标记，去重时与顶层**分桶**——顶层 config 块与 insert 子条目同 id 不再互相误判；insert 子条目之间、顶层条目之间的真重复仍能检出
2. **保留语义对齐**：writePatch / dev_fix_patch / fix-patch.mjs 注释声称「保留最后一条」但代码实际保留第一条——统一为倒序保留最后一条（与 loader 顺序覆盖语义一致）
3. **dev_fix_patch 重写保留顶格注释**
4. 版本 0.3.3 → 0.3.4，CHANGELOG 已更新

## 验证（本机实测）

- 旧事故形状（insert 子条目 dsh-vision + 顶层 config dsh-vision）：`--check` 健康（旧代码会误报重复）
- 嵌套子条目与顶层同 id（group config）：健康
- 真实重复（两个顶层 beta）：检出并保留最后一条，注释与 insert 子条目完好
- dev_fix_patch 工具与独立脚本 fix-patch.mjs 双路径均验证