### PR TITLE
fix: 设置页「超级模组」空白 + 与官方「插件」tab 重名

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,7 +4,19 @@
  *   - 直接注入：目录已是插件包（package.json + lib/）→ 立即注入
  *   - 内化：任意文件夹 → 新建 agent 会话 → AI 把内容变成插件
  * 通信：同源 fetch → host webServer API（/super-injector/api）
+ *
+ * ⚠️ 组件形态（2026-08-15 实测踩坑，issue #4）：settings.section 由
+ * dsh-client-web-react 渲染，`ctx.slots.register` 是官方双参契约
+ * `register(options, component)`，component 必须是返回合法 React 元素的
+ * **函数组件**（内部 jsx(Comp, props) 直接调用）。旧式单参写法把
+ * `component: () => ({ render() {} })` 塞进 options，React 会把返回的
+ * 对象判为无效元素 → 设置页入口存在但内容区永远空白。
+ * 修复：注册改为双参；`SuperInjectorPage` 用 useRef + useEffect 挂载
+ * 原有 vanilla DOM 子树（保持最小改动，原 DOM 构建逻辑基本不动）。
+ * label 用「超级模组」避免与官方设置页「插件」tab 重名。
  */
+import { createElement, useEffect, useRef } from 'react'
+import type { ReactElement } from 'react'
 import type { SlotsService } from '@deepseek-ai/dsh-client-ui-slots'
 
 type ClientContext = {
@@ -51,116 +63,129 @@ function fetchJson(path: string, init?: RequestInit): Promise<any> {
   }).then((r) => r.json())
 }
 
+/**
+ * 设置页内容组件（React 函数组件）。保持最小改动：把原有 vanilla DOM
+ * 构建逻辑整体放进 useEffect，挂载构造的子树，卸载时执行 dispose
+ * （清定时器）。DOM 内容与交互逻辑与旧实现完全一致。
+ */
+function SuperInjectorPage(): ReactElement {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const inst = (() => {
+      const style = document.createElement('style')
+      style.textContent = styles
+
+      const page = el('div', 'spi-page')
+      const h = el('h3', undefined, '插件管理（dsh-super-injector）')
+      const stats = el('p', 'spi-stats')
+      page.append(style, h, stats)
+
+      // ── 添加区 ──
+      const add = el('div', 'spi-add')
+      add.textContent = '拖入文件夹，或输入路径——「内化」= 新建会话让 AI 把内容变成插件；「注入」= 目录已是插件包直接注入'
+      const row = el('div', 'spi-row')
+      const input = el('input', 'spi-input') as HTMLInputElement
+      input.placeholder = 'D:/path/to/folder'
+      const btnIngest = el('button', 'spi-btn', '内化（AI 造插件）')
+      const btnInject = el('button', 'spi-btn ghost', '直接注入')
+      row.append(input, btnIngest, btnInject)
+      add.append(row)
+      page.append(add)
+
+      // 拖放（浏览器拿不到绝对路径——提示用输入框/选择器）
+      add.addEventListener('dragover', (e) => { e.preventDefault(); add.classList.add('drag') })
+      add.addEventListener('dragleave', () => add.classList.remove('drag'))
+      add.addEventListener('drop', (e) => {
+        e.preventDefault()
+        add.classList.remove('drag')
+        input.placeholder = '浏览器无法读取拖入文件夹的绝对路径——请粘贴路径或使用选择器'
+      })
+
+      // ── 列表 ──
+      const list = el('ul', 'spi-list')
+      page.append(list)
+
+      const msg = el('div', 'spi-msg')
+      msg.style.display = 'none'
+      page.append(msg)
+
+      const say = (text: string, isErr = false): void => {
+        msg.textContent = text
+        msg.style.display = text ? 'block' : 'none'
+        msg.style.borderColor = isErr ? '#d33' : 'var(--theme-border,#333)'
+      }
+
+      const refresh = (): void => {
+        fetchJson('/list')
+          .then((d) => {
+            if (!d?.ok) return say(JSON.stringify(d), true)
+            const { entries, stats: s } = d
+            stats.textContent = `inject ${s?.inject?.ok ?? 0}✓/${s?.inject?.fail ?? 0}✗ · reload ${s?.reload?.ok ?? 0}✓ · uninject ${s?.uninject?.ok ?? 0}✓/${s?.uninject?.fail ?? 0}✗ · 共 ${entries.length} 个注入插件`
+            list.textContent = ''
+            if (!entries.length) {
+              list.append(el('li', 'spi-item', '（暂无注入插件——拖入文件夹或输入路径开始）'))
+              return
+            }
+            for (const e of entries) {
+              const li = el('li', 'spi-item')
+              const name = el('span', 'name', String(e.name))
+              const dir = el('span', 'dir', String(e.dir))
+              const st = el('span', 'st ' + (e.active ? 'on' : 'off'), e.active ? '运行中' : '未激活')
+              const btn = el('button', 'spi-btn danger', '卸载')
+              btn.addEventListener('click', () => {
+                btn.disabled = true
+                btn.textContent = '卸载中…'
+                fetchJson('/uninstall', { method: 'POST', body: JSON.stringify({ match: e.name }) })
+                  .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok) })
+                  .catch((err) => say('卸载请求失败: ' + err, true))
+                  .finally(() => { btn.disabled = false; btn.textContent = '卸载'; setTimeout(refresh, 600) })
+              })
+              li.append(name, dir, st, btn)
+              list.append(li)
+            }
+          })
+          .catch((err) => say('加载失败: ' + err, true))
+      }
+
+      const doAction = (path: string, label: string): void => {
+        const dir = input.value.trim()
+        if (!dir) { say('请先输入文件夹路径', true); return }
+        btnIngest.disabled = btnInject.disabled = true
+        btnIngest.textContent = btnInject.textContent = '处理中…'
+        say('')
+        fetchJson(path, { method: 'POST', body: JSON.stringify({ dir, title: label }) })
+          .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok); if (r?.ok) setTimeout(refresh, 1200) })
+          .catch((err) => say('请求失败: ' + err, true))
+          .finally(() => {
+            btnIngest.disabled = btnInject.disabled = false
+            btnIngest.textContent = '内化（AI 造插件）'
+            btnInject.textContent = '直接注入'
+          })
+      }
+      btnIngest.addEventListener('click', () => doAction('/ingest', '内化插件'))
+      btnInject.addEventListener('click', () => doAction('/inject', '直接注入'))
+
+      refresh()
+      // 60s 轮询刷新（内化会话建好后自动出现）
+      const timer = window.setInterval(refresh, 60000)
+      return { page, dispose: () => window.clearInterval(timer) }
+    })()
+
+    if (ref.current && inst.page) ref.current.appendChild(inst.page)
+    return inst.dispose
+  }, [])
+
+  return createElement('div', { ref })
+}
+
 export function apply(ctx: ClientContext): void {
   ctx.effect(() => ctx.slots.inject('settings.section', () =>
     ctx.slots.register({
       name: 'settings.section',
       id: 'super-injector-plugins',
       order: 50,
-      label: () => '插件',
-      component: () => ({
-        render() {
-          const style = document.createElement('style')
-          style.textContent = styles
-
-          const page = el('div', 'spi-page')
-          const h = el('h3', undefined, '插件管理（dsh-super-injector）')
-          const stats = el('p', 'spi-stats')
-          page.append(style, h, stats)
-
-          // ── 添加区 ──
-          const add = el('div', 'spi-add')
-          add.textContent = '拖入文件夹，或输入路径——「内化」= 新建会话让 AI 把内容变成插件；「注入」= 目录已是插件包直接注入'
-          const row = el('div', 'spi-row')
-          const input = el('input', 'spi-input') as HTMLInputElement
-          input.placeholder = 'D:/path/to/folder'
-          const btnIngest = el('button', 'spi-btn', '内化（AI 造插件）')
-          const btnInject = el('button', 'spi-btn ghost', '直接注入')
-          row.append(input, btnIngest, btnInject)
-          add.append(row)
-          page.append(add)
-
-          // 拖放（浏览器拿不到绝对路径——提示用输入框/选择器）
-          add.addEventListener('dragover', (e) => { e.preventDefault(); add.classList.add('drag') })
-          add.addEventListener('dragleave', () => add.classList.remove('drag'))
-          add.addEventListener('drop', (e) => {
-            e.preventDefault()
-            add.classList.remove('drag')
-            input.placeholder = '浏览器无法读取拖入文件夹的绝对路径——请粘贴路径或使用选择器'
-          })
-
-          // ── 列表 ──
-          const list = el('ul', 'spi-list')
-          page.append(list)
-
-          const msg = el('div', 'spi-msg')
-          msg.style.display = 'none'
-          page.append(msg)
-
-          const say = (text: string, isErr = false): void => {
-            msg.textContent = text
-            msg.style.display = text ? 'block' : 'none'
-            msg.style.borderColor = isErr ? '#d33' : 'var(--theme-border,#333)'
-          }
-
-          const refresh = (): void => {
-            fetchJson('/list')
-              .then((d) => {
-                if (!d?.ok) return say(JSON.stringify(d), true)
-                const { entries, stats: s } = d
-                stats.textContent = `inject ${s?.inject?.ok ?? 0}✓/${s?.inject?.fail ?? 0}✗ · reload ${s?.reload?.ok ?? 0}✓ · uninject ${s?.uninject?.ok ?? 0}✓/${s?.uninject?.fail ?? 0}✗ · 共 ${entries.length} 个注入插件`
-                list.textContent = ''
-                if (!entries.length) {
-                  list.append(el('li', 'spi-item', '（暂无注入插件——拖入文件夹或输入路径开始）'))
-                  return
-                }
-                for (const e of entries) {
-                  const li = el('li', 'spi-item')
-                  const name = el('span', 'name', String(e.name))
-                  const dir = el('span', 'dir', String(e.dir))
-                  const st = el('span', 'st ' + (e.active ? 'on' : 'off'), e.active ? '运行中' : '未激活')
-                  const btn = el('button', 'spi-btn danger', '卸载')
-                  btn.addEventListener('click', () => {
-                    btn.disabled = true
-                    btn.textContent = '卸载中…'
-                    fetchJson('/uninstall', { method: 'POST', body: JSON.stringify({ match: e.name }) })
-                      .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok) })
-                      .catch((err) => say('卸载请求失败: ' + err, true))
-                      .finally(() => { btn.disabled = false; btn.textContent = '卸载'; setTimeout(refresh, 600) })
-                  })
-                  li.append(name, dir, st, btn)
-                  list.append(li)
-                }
-              })
-              .catch((err) => say('加载失败: ' + err, true))
-          }
-
-          const doAction = (path: string, label: string): void => {
-            const dir = input.value.trim()
-            if (!dir) { say('请先输入文件夹路径', true); return }
-            btnIngest.disabled = btnInject.disabled = true
-            btnIngest.textContent = btnInject.textContent = '处理中…'
-            say('')
-            fetchJson(path, { method: 'POST', body: JSON.stringify({ dir, title: label }) })
-              .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok); if (r?.ok) setTimeout(refresh, 1200) })
-              .catch((err) => say('请求失败: ' + err, true))
-              .finally(() => {
-                btnIngest.disabled = btnInject.disabled = false
-                btnIngest.textContent = '内化（AI 造插件）'
-                btnInject.textContent = '直接注入'
-              })
-          }
-          btnIngest.addEventListener('click', () => doAction('/ingest', '内化插件'))
-          btnInject.addEventListener('click', () => doAction('/inject', '直接注入'))
-
-          refresh()
-          // 60s 轮询刷新（内化会话建好后自动出现）
-          const timer = window.setInterval(refresh, 60000)
-          return {
-            dispose: () => window.clearInterval(timer),
-          }
-        },
-      }),
-    }),
+      label: () => '超级模组',
+    }, SuperInjectorPage),
   ), 'super-injector: settings page')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,8 @@ const SCAFFOLD_TSCONFIG = `{
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/client"]
 }
 `
 
@@ -363,10 +364,14 @@ export function apply(ctx: Context, config: Config): void {
 const SCAFFOLD_UI_CLIENT = (pkgName: string): string => `/**
  * ${pkgName} — client 面板（conversation.view slot）。
  * 构建：npm run build:client（tsdown，产物 lib/client.js，ModuleLoader.load 注册）。
- * ⚠️ 两个必坑（2026-08 实测）：① apply 用 ctx.slots 必须 export const inject
- * = ['slots']（服务注入声明）；② register 必须带 name 字段（= slot 名，
- * 如 conversation.view）——缺 name 报 "slot undefined is not declared"。
+ * ⚠️ 三个必坑（2026-08 实测，含 issue #4 blank page）：① apply 用 ctx.slots
+ * 必须 export const inject = ['slots']（服务注入声明）；② register 必须带 name
+ * 字段（= slot 名，如 conversation.view）——缺 name 报 "slot undefined is
+ * not declared"；③ register 是双参契约 register(options, component)，component
+ * 必须是返回合法 React 元素的**函数组件**（内部 jsx(Comp, props) 直接调用）——
+ * 旧式单参 component: () => ({ render() {} }) 会把页面渲染成空白。
  */
+import { createElement } from 'react'
 import type { SlotsService } from '@deepseek-ai/dsh-client-ui-slots'
 
 type ClientContext = {
@@ -375,22 +380,17 @@ type ClientContext = {
 
 export const inject = ['slots']
 
+function Panel(): any {
+  return createElement('div', { style: { padding: '12px', fontFamily: 'monospace' } }, ${JSON.stringify(pkgName)} + ' 面板（host API: /${pkgName}/api）')
+}
+
 export function apply(ctx: ClientContext): void {
   ctx.effect(() => ctx.slots.inject('conversation.view', () =>
     ctx.slots.register({
       name: 'conversation.view',
       id: '${pkgName}-panel',
       label: () => ${JSON.stringify(pkgName)},
-      component: () => ({
-        render() {
-          const el = document.createElement('div')
-          el.textContent = ${JSON.stringify(pkgName)} + ' 面板（host API: /${pkgName}/api）'
-          el.style.padding = '12px'
-          el.style.fontFamily = 'monospace'
-          return el
-        },
-      }),
-    }),
+    }, Panel),
   ), '${pkgName}: panel')
 }
 `
@@ -3178,18 +3178,45 @@ export function apply(ctx: AppContext, config: Config): void {
   // client-modules 首次扫描时 junction 可能未建 → resolvePkgJson 抛 →
   // pkgMeta 缓存 null（进程级永久，无官方清缓存 API）→ client 永不注册
   // （设置页「插件」不出现）。junction 已建立后：清缓存 + 重解析注册。
-  try {
-    const cmSvc = ctx.get('clientModules') as {
-      pkgMeta?: Map<string, unknown>
-      processOne?: (name: string) => unknown
-    } | undefined
-    if (cmSvc?.pkgMeta && typeof cmSvc.pkgMeta.delete === 'function') {
+  // ⚠️ 自重载时序（2026-08-15 实测，issue #4 根因③）：apply 期间自身 entry
+  // 可能仍带 disabled 标记，processOne 会误删表行；且 processOne 只改 table、
+  // 不重组合图（composed）→ boot manifest 缺行 → 设置页入口丢失。修复：
+  // 延迟到 fiber 激活后再清缓存 → processOne → rebuilt（重算 rev + 重组
+  // 合图 + 通知），保证 client-modules compose 与表一致。
+  const healClientMeta = (): void => {
+    try {
+      const root = (ctx.root ?? ctx) as any
+      const cmSvc = root.get('clientModules') as {
+        pkgMeta?: Map<string, unknown>
+        table?: Map<string, unknown>
+        processOne?: (name: string) => unknown
+        compose?: () => unknown
+        composed?: unknown
+        notifyGraphChanged?: () => void
+      } | undefined
+      if (!cmSvc?.pkgMeta || typeof cmSvc.pkgMeta.delete !== 'function') return
       cmSvc.pkgMeta.delete('@dsh-external/dsh-super-injector')
       if (typeof cmSvc.processOne === 'function') {
         cmSvc.processOne('@dsh-external/dsh-super-injector')
-        auditLog('client-meta-healed', 'client-modules pkgMeta 缓存已清并重解析（设置页插件管理 UI 注册）')
       }
+      // 表行恢复后必须显式重组合图：processOne 只写 table，不改 composed；
+      // rebuilt 在同 rev 时会提前 return，也不重组合图——直接用 compose 赋值
+      // + notifyGraphChanged，保证 boot manifest 与 table 一致。
+      if (cmSvc.table?.has('@dsh-external/dsh-super-injector')) {
+        cmSvc.composed = cmSvc.compose?.()
+        cmSvc.notifyGraphChanged?.()
+      }
+      auditLog('client-meta-healed', 'client-modules pkgMeta 缓存已清并重解析（设置页插件管理 UI 注册）')
+    } catch (e) {
+      auditLog('client-meta-heal-failed', String(e))
     }
+  }
+  try {
+    // 冷启动立即执行一次；自重载场景补一发延迟执行，等自身 fiber 激活、
+    // disabled 清掉后重试（幂等：table 已有行时 processOne 不重复加，
+    // compose+notify 重复执行也安全）。
+    healClientMeta()
+    globalThis.setTimeout(() => healClientMeta(), 1000)
   } catch { /* 缓存自愈失败不阻塞 */ }
 
   // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
# 修复设置页「超级模组」空白 + 与官方「插件」tab 重名

## 摘要

`settings.section` 插件管理面板存在两个问题：

1. **设置页入口存在但内容区空白**：因为 `ctx.slots.register` 用了单参调用，把
   `component: () => ({ render() {} })` 塞进 options；官方 DSH slots 契约是双参
   `register(options, component)`，且 component 必须是**返回合法 React 元素的函数组件**。
   旧式对象形态会被 React 判为无效元素，导致内容区永远空白。
2. **tab 重名**：label 是「插件」，与官方设置页「插件」tab 重名。

## 根因

详见 issue #4。除上述 client 注册形态错误外，还暴露了另外两个根因，本次一并修复：

- **根因 ②**：`dev_scaffold_plugin` 生成的 UI 面板模板同样用了错误的单参对象组件，
  会把这些坑复制给所有新生成的插件骨架。
- **根因 ③**：自重载（self-reload）后 client-modules 的 `composed` 组合图未重组，
  `processOne` 只改 `table` 不改 `composed`，导致 boot manifest 缺行、设置页入口丢失。
  修复为清 `pkgMeta` → `processOne` → 显式重组 `composed` + `notifyGraphChanged`，
  并延后到自身 fiber 激活（disabled 清掉）后执行，保证组合图与表一致。

> 注：本 PR 的根因②/③ 变更对齐了 Testallin 在 issue #4 附带的 patch 思路
> （github.com/user-attachments/files/31099531）。根因① 采用最小改动方案
> （useRef + useEffect 挂载原有 vanilla DOM 子树），DOM 内容与交互逻辑与原先一致。

## 修复内容

- `src/client/index.ts`（根因① + 改名）：
  - 注册改为官方双参 `register({ name, id, order, label }, SuperInjectorPage)`
  - `SuperInjectorPage` 为 React 函数组件（`useRef` + `useEffect` 挂载原有 vanilla DOM
    子树，保持最小改动，原 DOM 构建逻辑基本不动）
  - `label` 改为「超级模组」，消除与官方「插件」tab 重名
- `src/index.ts`（根因②③）：
  - `SCAFFOLD_UI_CLIENT` 模板改为 React 函数组件双参注册；`SCAFFOLD_TSCONFIG` 增加
    `exclude: ["src/client"]`（host tsc 不编译浏览器端）
  - client-modules `pkgMeta` 自愈改为「清缓存 → processOne → 显式重组 composed +
    notifyGraphChanged」，冷启动立即执行一次 + 自重载场景延后 1s 补发一次

## 验证

- **渲染回归测试（jsdom + React 18）通过**：对修复后 client 转译产物执行
  `ReactDOM.render(<entry.component/>)`，确认两参注册、label 为「超级模组」，且函数组件
  真正挂载出完整 DOM 子树（h3 / 输入框 / 「内化」「直接注入」按钮 / 空态提示 / 统计行）。
- **已在个人生产实例实际生效**：设置页已能正常显示与管理注入插件。
- 本地可用的独立 `tsc` 对改动后的 `src/index.ts` 语法编译通过，无新增语法错误。

> 未能运行仓库完整 `npm ci + npm run build`：`npm ci` 因依赖 `@deepseek-ai/dsh-type-meta`
> 的私有预发布包无法从公共 registry 解析而失败。故上述验证以
> 客户端渲染回归与语义一致校验为主，完整构建待有依赖访问权限的环境补齐。
