### PR TITLE
fix: listPlugins 守卫 loader.internal，无 --expose-internals 时 dev_plugin_status 崩溃

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1375,8 +1375,10 @@ export function apply(ctx: AppContext, config: Config): void {
       const opts = entry.options
       if (opts.group) continue
       const state = entry.fiber ? (FIBER_NAMES[entry.fiber.state] ?? `state:${entry.fiber.state}`) : 'no-fiber'
-      const entryUrl = [...ctx.loader.internal!.loadCache.keys()]
-        .find(u => typeof u === 'string' && u.includes(opts.id))
+      // 守卫：loader.internal 仅在 --expose-internals 启动时存在（Web GUI 不带此 flag）
+      const entryUrl = ctx.loader.internal?.loadCache
+        ? [...ctx.loader.internal.loadCache.keys()].find(u => typeof u === 'string' && u.includes(opts.id))
+        : undefined
       // 注入插件标记 [injected]（与 bundle 装配区分，避免 hash id 难认）
       const injected = injectedNames.has(opts.name) ? ' [injected]' : ''
       lines.push(`- [${state}] ${opts.id} (${opts.name})${injected}${opts.disabled ? ' [disabled]' : ''}${entryUrl ? '\n    entry: ' + entryUrl : ''}`)


### PR DESCRIPTION
关联 issue：#10

## 问题

`dev_plugin_status` 在无 `--expose-internals` 的启动方式下（如 DSH Desktop Web GUI）直接崩溃：

```
Error: Cannot read properties of undefined (reading 'loadCache')
```

## 根因

`listPlugins()` 中未判空访问 `ctx.loader.internal.loadCache`，而 `ctx.loader.internal` 仅在以 `--expose-internals` 启动时存在（宿主 `cordis-plugin-hmr`：`--expose-internals is required for HMR service`）。桌面终端 shim 启动带该 flag，Web GUI 不带。其余路径（`reloadPackage`、自愈逻辑）均有 `if (!internal)` 守卫，唯 `listPlugins` 漏了。

## 修复

`src/index.ts` `listPlugins()`：optional chaining 守卫 + 注释，与其他路径的防御风格一致。

```diff
-      const entryUrl = [...ctx.loader.internal!.loadCache.keys()]
-        .find(u => typeof u === 'string' && u.includes(opts.id))
+      // 守卫：loader.internal 仅在 --expose-internals 启动时存在（Web GUI 不带此 flag）
+      const entryUrl = ctx.loader.internal?.loadCache
+        ? [...ctx.loader.internal.loadCache.keys()].find(u => typeof u === 'string' && u.includes(opts.id))
+        : undefined
```

## 验证

- 修复前（Web GUI，无 `--expose-internals`）：`dev_plugin_status` 抛 `Cannot read properties of undefined (reading 'loadCache')`
- 修复后：`dev_plugin_status` 正常返回插件清单（无 `--expose-internals` 时不显示 entry URL，属合理降级）；`dev_injected_list` 等其余工具不受影响

## 备注（未含在本 PR）

- 注入器热重载 / loadCache 清理等完整能力依赖 `--expose-internals`；建议后续在 README/INSTALL 注明该前提
- 本地安装副本 `~/dsh-super-injector/lib/index.js` 已同步此修复，重启后生效
