### PR TITLE
fix(build): link @types/node; pin .sh to LF (Windows CRLF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must stay LF: CRLF breaks bash ("set -o pipefail" fails
+# with "invalid option name" because of the trailing \r), and Windows
+# checkouts with core.autocrlf=true would otherwise convert them.
+*.sh text eol=lf

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,6 +44,8 @@ link_pkg schemastery vendor/schemastery
 link_pkg @deepseek-ai/dsh-tools packages/core/tools
 link_pkg @deepseek-ai/dsh-system-prompt packages/core/system-prompt
 link_pkg @deepseek-ai/cordis-plugin-loader vendor/loader
+# @types/node（tsconfig 的 "types": ["node"]；checkout 自带）
+link_pkg @types/node node_modules/@types/node
 
 STD_SCHEMA=$(find "$CHECKOUT/node_modules/.pnpm" -maxdepth 1 -type d -iname '@standard-schema+spec@*' 2>/dev/null | head -1)
 if [ -n "$STD_SCHEMA" ]; then


### PR DESCRIPTION
# fix(build): link `@types/node`; pin `.sh` to LF

两个独立的 Windows 构建问题：

## 1. `scripts/build.sh` 缺少 `@types/node` 链接（TS2688）

`tsconfig.json` 声明了 `"types": ["node"]`，但 `scripts/build.sh` 只链接了 cordis/cosmokit/schemastery/dsh-tools/dsh-system-prompt/cordis-plugin-loader，**没有链接 `@types/node`**。在 fresh 的 dsh checkout 上构建直接报：

```
error TS2688: Cannot find type definition file for 'node'.
```

本仓库 `src/index.ts` 里的脚手架模板（`SCAFFOLD_BUILD_SH`）是有这行的（`link_pkg @types/node node_modules/@types/node`），仓库自带的 `scripts/build.sh` 漏了。补上：

```bash
link_pkg @types/node node_modules/@types/node
```

## 2. CRLF 行尾破坏 bash（`set: pipefail: invalid option name`）

Windows 用户 `core.autocrlf=true` 时，`.sh` 被检出为 CRLF，bash 把 `set -euo pipefail` 读成 `pipefail\r` 直接报错。新增 `.gitattributes`：

```gitattributes
*.sh text eol=lf
```

## 验证

Windows + Git Bash 实测：

- 修复前：`bash scripts/build.sh` → `line 4: set: pipefail: invalid option name`
- 修复后：`DSH_CHECKOUT=<dsh checkout> bash scripts/build.sh` → `=== Build complete ===`（tsc 6.0.3 编译产出 `lib/index.js`）

（注：fresh 的 deepseek-harness checkout 需要先用 `tsc -b` 构建依赖包的类型声明，这是构建环境问题，与本次脚本修复无关，但如需可另行说明。）
