### PR TITLE
fix(client): 设置页「插件」选项空白 — 按 register(options, component) 契约注册真 React 组件

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -4,8 +4,16 @@
  *   - 直接注入：目录已是插件包（package.json + lib/）→ 立即注入
  *   - 内化：任意文件夹 → 新建 agent 会话 → AI 把内容变成插件
  * 通信：同源 fetch → host webServer API（/super-injector/api）
+ *
+ * 修复（dsh-routing-suite#1：Web 设置页「插件」选项空白）：此前把 `component`
+ * 塞进 `register(options, component)` 的 options 里，被插槽核心静默丢弃——label
+ * 生效但组件未注册，点开设置页永远空白。现改为把真正的 React 函数组件作为
+ * 第二个位置参数传入（与官方 settings.section 注册方式一致）；同时把 label 由
+ * 「插件」改为「插件管理」，避免与官方设置页「插件」重名。
  */
 import type { SlotsService } from '@deepseek-ai/dsh-client-ui-slots'
+import { useCallback, useEffect, useState, type ChangeEvent, type DragEvent } from 'react'
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime'
 
 type ClientContext = {
   slots: SlotsService
@@ -14,13 +22,6 @@ type ClientContext = {
 export const inject = ['slots']
 
 const API = '/super-injector/api'
-
-function el(tag: string, cls?: string, text?: string): HTMLElement {
-  const e = document.createElement(tag)
-  if (cls) e.className = cls
-  if (text !== void 0) e.textContent = text
-  return e
-}
 
 const styles = `
 .spi-page{font-family:ui-monospace,monospace;font-size:12px;line-height:1.6;padding:14px 16px;max-width:720px}
@@ -51,116 +52,179 @@ function fetchJson(path: string, init?: RequestInit): Promise<any> {
   }).then((r) => r.json())
 }
 
+/**
+ * 插件管理设置页（React 函数组件）。
+ * 经 `ctx.slots.register(options, Component)` 的第二个位置参数注册，由插槽
+ * 渲染系统接管；不能再写 `component: () => ({ render(){} })`（会被插槽核心丢弃）。
+ */
+function SuperInjectorPluginsSection() {
+  const [entries, setEntries] = useState<any[]>([])
+  const [stats, setStats] = useState<any>(null)
+  const [msg, setMsg] = useState<string | null>(null)
+  const [msgErr, setMsgErr] = useState(false)
+  const [dir, setDir] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [busyName, setBusyName] = useState<string | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const [dropHint, setDropHint] = useState('D:/path/to/folder')
+
+  const refresh = useCallback(() => {
+    fetchJson('/list')
+      .then((d) => {
+        if (!d?.ok) {
+          setMsg(JSON.stringify(d))
+          setMsgErr(true)
+          return
+        }
+        setEntries(d.entries ?? [])
+        setStats(d.stats ?? {})
+        setMsg(null)
+        setMsgErr(false)
+      })
+      .catch((err) => {
+        setMsg('加载失败: ' + err)
+        setMsgErr(true)
+      })
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    // 60s 轮询刷新（内化会话建好后自动出现）
+    const timer = window.setInterval(refresh, 60000)
+    return () => window.clearInterval(timer)
+  }, [refresh])
+
+  const say = (text: string | null, isErr = false): void => {
+    setMsg(text)
+    setMsgErr(isErr)
+  }
+
+  const doAction = (path: string, label: string): void => {
+    const value = dir.trim()
+    if (!value) {
+      say('请先输入文件夹路径', true)
+      return
+    }
+    setBusy(true)
+    setMsg(null)
+    fetchJson(path, { method: 'POST', body: JSON.stringify({ dir: value, title: label }) })
+      .then((r) => {
+        say(r?.result ?? JSON.stringify(r), !r?.ok)
+        if (r?.ok) setTimeout(refresh, 1200)
+      })
+      .catch((err) => say('请求失败: ' + err, true))
+      .finally(() => setBusy(false))
+  }
+
+  const doUninstall = (name: string): void => {
+    setBusyName(name)
+    fetchJson('/uninstall', { method: 'POST', body: JSON.stringify({ match: name }) })
+      .then((r) => {
+        say(r?.result ?? JSON.stringify(r), !r?.ok)
+      })
+      .catch((err) => say('卸载请求失败: ' + err, true))
+      .finally(() => {
+        setBusyName(null)
+        setTimeout(refresh, 600)
+      })
+  }
+
+  const statsText = stats
+    ? `inject ${stats.inject?.ok ?? 0}✓/${stats.inject?.fail ?? 0}✗ · reload ${stats.reload?.ok ?? 0}✓ · uninject ${stats.uninject?.ok ?? 0}✓/${stats.uninject?.fail ?? 0}✗ · 共 ${entries.length} 个注入插件`
+    : '正在读取插件…'
+
+  return jsxs(Fragment, {
+    children: [
+      jsx('style', { children: styles }),
+      jsx('div', {
+        className: 'spi-page',
+        children: jsxs(Fragment, {
+          children: [
+            jsx('h3', { children: '插件管理（dsh-super-injector）' }),
+            jsx('p', { className: 'spi-stats', children: statsText }),
+            jsx('div', {
+              className: 'spi-add' + (dragging ? ' drag' : ''),
+              onDragOver: (e: DragEvent<HTMLDivElement>) => {
+                e.preventDefault()
+                setDragging(true)
+              },
+              onDragLeave: () => setDragging(false),
+              onDrop: (e: DragEvent<HTMLDivElement>) => {
+                e.preventDefault()
+                setDragging(false)
+                setDropHint('浏览器无法读取拖入文件夹的绝对路径——请粘贴路径或使用选择器')
+              },
+              children: jsxs(Fragment, {
+                children: [
+                  '拖入文件夹，或输入路径——「内化」= 新建会话让 AI 把内容变成插件；「注入」= 目录已是插件包直接注入',
+                  jsx('div', {
+                    className: 'spi-row',
+                    children: jsxs(Fragment, {
+                      children: [
+                        jsx('input', {
+                          className: 'spi-input',
+                          placeholder: dropHint,
+                          value: dir,
+                          onChange: (e: ChangeEvent<HTMLInputElement>) => setDir(e.target.value),
+                        }),
+                        jsx('button', {
+                          className: 'spi-btn',
+                          disabled: busy,
+                          onClick: () => doAction('/ingest', '内化插件'),
+                          children: busy ? '处理中…' : '内化（AI 造插件）',
+                        }),
+                        jsx('button', {
+                          className: 'spi-btn ghost',
+                          disabled: busy,
+                          onClick: () => doAction('/inject', '直接注入'),
+                          children: busy ? '处理中…' : '直接注入',
+                        }),
+                      ],
+                    }),
+                  }),
+                ],
+              }),
+            }),
+            jsx('ul', {
+              className: 'spi-list',
+              children: entries.length === 0
+                ? jsx('li', { className: 'spi-item', children: '（暂无注入插件——拖入文件夹或输入路径开始）' })
+                : entries.map((e) => jsx('li', {
+                    className: 'spi-item',
+                    children: jsxs(Fragment, {
+                      children: [
+                        jsx('span', { className: 'name', children: String(e.name) }),
+                        jsx('span', { className: 'dir', children: String(e.dir) }),
+                        jsx('span', { className: 'st ' + (e.active ? 'on' : 'off'), children: e.active ? '运行中' : '未激活' }),
+                        jsx('button', {
+                          className: 'spi-btn danger',
+                          disabled: busyName === e.name,
+                          onClick: () => doUninstall(e.name),
+                          children: busyName === e.name ? '卸载中…' : '卸载',
+                        }),
+                      ],
+                    }),
+                  }, String(e.name))),
+            }),
+            msg ? jsx('div', {
+              className: 'spi-msg',
+              style: msgErr ? { borderColor: '#d33' } : undefined,
+              children: msg,
+            }) : null,
+          ],
+        }),
+      }),
+    ],
+  })
+}
+
 export function apply(ctx: ClientContext): void {
   ctx.effect(() => ctx.slots.inject('settings.section', () =>
     ctx.slots.register({
       name: 'settings.section',
       id: 'super-injector-plugins',
       order: 50,
-      label: () => '插件',
-      component: () => ({
-        render() {
-          const style = document.createElement('style')
-          style.textContent = styles
-
-          const page = el('div', 'spi-page')
-          const h = el('h3', undefined, '插件管理（dsh-super-injector）')
-          const stats = el('p', 'spi-stats')
-          page.append(style, h, stats)
-
-          // ── 添加区 ──
-          const add = el('div', 'spi-add')
-          add.textContent = '拖入文件夹，或输入路径——「内化」= 新建会话让 AI 把内容变成插件；「注入」= 目录已是插件包直接注入'
-          const row = el('div', 'spi-row')
-          const input = el('input', 'spi-input') as HTMLInputElement
-          input.placeholder = 'D:/path/to/folder'
-          const btnIngest = el('button', 'spi-btn', '内化（AI 造插件）')
-          const btnInject = el('button', 'spi-btn ghost', '直接注入')
-          row.append(input, btnIngest, btnInject)
-          add.append(row)
-          page.append(add)
-
-          // 拖放（浏览器拿不到绝对路径——提示用输入框/选择器）
-          add.addEventListener('dragover', (e) => { e.preventDefault(); add.classList.add('drag') })
-          add.addEventListener('dragleave', () => add.classList.remove('drag'))
-          add.addEventListener('drop', (e) => {
-            e.preventDefault()
-            add.classList.remove('drag')
-            input.placeholder = '浏览器无法读取拖入文件夹的绝对路径——请粘贴路径或使用选择器'
-          })
-
-          // ── 列表 ──
-          const list = el('ul', 'spi-list')
-          page.append(list)
-
-          const msg = el('div', 'spi-msg')
-          msg.style.display = 'none'
-          page.append(msg)
-
-          const say = (text: string, isErr = false): void => {
-            msg.textContent = text
-            msg.style.display = text ? 'block' : 'none'
-            msg.style.borderColor = isErr ? '#d33' : 'var(--theme-border,#333)'
-          }
-
-          const refresh = (): void => {
-            fetchJson('/list')
-              .then((d) => {
-                if (!d?.ok) return say(JSON.stringify(d), true)
-                const { entries, stats: s } = d
-                stats.textContent = `inject ${s?.inject?.ok ?? 0}✓/${s?.inject?.fail ?? 0}✗ · reload ${s?.reload?.ok ?? 0}✓ · uninject ${s?.uninject?.ok ?? 0}✓/${s?.uninject?.fail ?? 0}✗ · 共 ${entries.length} 个注入插件`
-                list.textContent = ''
-                if (!entries.length) {
-                  list.append(el('li', 'spi-item', '（暂无注入插件——拖入文件夹或输入路径开始）'))
-                  return
-                }
-                for (const e of entries) {
-                  const li = el('li', 'spi-item')
-                  const name = el('span', 'name', String(e.name))
-                  const dir = el('span', 'dir', String(e.dir))
-                  const st = el('span', 'st ' + (e.active ? 'on' : 'off'), e.active ? '运行中' : '未激活')
-                  const btn = el('button', 'spi-btn danger', '卸载')
-                  btn.addEventListener('click', () => {
-                    btn.disabled = true
-                    btn.textContent = '卸载中…'
-                    fetchJson('/uninstall', { method: 'POST', body: JSON.stringify({ match: e.name }) })
-                      .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok) })
-                      .catch((err) => say('卸载请求失败: ' + err, true))
-                      .finally(() => { btn.disabled = false; btn.textContent = '卸载'; setTimeout(refresh, 600) })
-                  })
-                  li.append(name, dir, st, btn)
-                  list.append(li)
-                }
-              })
-              .catch((err) => say('加载失败: ' + err, true))
-          }
-
-          const doAction = (path: string, label: string): void => {
-            const dir = input.value.trim()
-            if (!dir) { say('请先输入文件夹路径', true); return }
-            btnIngest.disabled = btnInject.disabled = true
-            btnIngest.textContent = btnInject.textContent = '处理中…'
-            say('')
-            fetchJson(path, { method: 'POST', body: JSON.stringify({ dir, title: label }) })
-              .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok); if (r?.ok) setTimeout(refresh, 1200) })
-              .catch((err) => say('请求失败: ' + err, true))
-              .finally(() => {
-                btnIngest.disabled = btnInject.disabled = false
-                btnIngest.textContent = '内化（AI 造插件）'
-                btnInject.textContent = '直接注入'
-              })
-          }
-          btnIngest.addEventListener('click', () => doAction('/ingest', '内化插件'))
-          btnInject.addEventListener('click', () => doAction('/inject', '直接注入'))
-
-          refresh()
-          // 60s 轮询刷新（内化会话建好后自动出现）
-          const timer = window.setInterval(refresh, 60000)
-          return {
-            dispose: () => window.clearInterval(timer),
-          }
-        },
-      }),
-    }),
+      label: () => '插件管理',
+    }, SuperInjectorPluginsSection)
   ), 'super-injector: settings page')
 }


### PR DESCRIPTION
## 问题

Web 设置页出现「插件」项，但点击后**整页空白**（对应 [dsh-routing-suite#1](https://github.com/yjh051108/dsh-routing-suite/issues/1) 的 Bug 2）。

## 根因

`src/client/index.ts` 里把渲染组件塞进了 `register` 的 **options 对象**：

```ts
ctx.slots.register({
  name: 'settings.section',
  id: 'super-injector-plugins',
  order: 50,
  label: () => '插件',
  component: () => ({ render() { ... } }),  // ← 写在 options 里，被丢弃
})
```

但 DSH 插槽契约是 `register(options, component)` —— 组件必须作为**第二个位置参数**传入。
插槽核心（`dsh-client-ui-slots`）在构造 entry 时只取第二个参数 `component`，`options.component`
被静默丢弃 → `entry.component === undefined`。渲染器 `jsx(undefined, ...)` 抛 React #130，
被条目级 `SlotErrorBoundary` 吞掉，渲染成空的 `data-slot-error` 节点。所以 label 生效（导航里有
「插件」），页面却永远空白。v0.3.3 源码仍如此，与 issue 中 KureKaruna 的诊断一致。

## 修复

- 页面改写为**真正的 React 函数组件**（hooks：`useState/useEffect/useCallback`），
  作为 `ctx.slots.register` 的**第二个位置参数**传入（与官方 settings.section 注册方式一致）；
- 保留全部功能：已注入列表 / 一键卸载 / 路径输入 / 拖放提示 / 内化（AI 造插件）/ 直接注入 /
  60s 轮询刷新 / 错误提示；
- label 由「插件」改为「**插件管理**」，避免与官方设置页「插件」重名（顺带消除“多余的插件页”）。

## 验证

- `tsdown` 构建 `lib/client.js` 成功（8.95 kB）；
- 在实装 Web 设置页实测：导航显示「插件管理」，点开后正常渲染
  标题/统计/输入框/内化/直接注入/列表，不再空白；无 React #130 报错。

## 影响

仅客户端 `src/client/index.ts`；host 端 `dev_*` 工具与 API 不受影响。