### PR TITLE
fix(heal): dev_heal_links 悬空 junction 误报「全部健康」

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 > **版本以 git tag 为准**：已发布 v0.3.1 / v0.3.3（GitHub Releases 资产）；未打 tag 的
 > 小节为开发史（其内容随下一个发布一并交付）。
 
+## [Unreleased]
+
+### 修复
+
+- **`dev_heal_links` 悬空 junction 误报「全部健康」修复（issue #19）**：删除守卫改用
+  `lstatSync` 判断链接本身存在——`existsSync` 跟随链接检查目标，对悬空 junction 返回
+  false，残留坏链接删除失败、重建撞 EEXIST 被吞，误报「全部健康」。与注入路径
+  `dev_inject_plugin` 的既有写法保持一致。
+
 ## [0.3.3] — 2026-08-15（已发布，git tag v0.3.3）
 
 ### 更新（高性能引导升级为 P1-P23 完整认知）

--- a/src/index.ts
+++ b/src/index.ts
@@ -2224,9 +2224,15 @@ export function apply(ctx: AppContext, config: Config): void {
         const linkDir = join(profileNodeModules, scope ?? '')
         const linkPath = join(linkDir, scope ? name.split('/')[1] as string : name)
         if (!isHealthyLink(linkPath)) {
-          try {
-            if (existsSync(linkPath)) rmdirSync(linkPath)
-          } catch { /* 坏链接删除失败忽略 */ }
+          // ⚠️ 悬空 junction 的删除守卫必须用 lstatSync 判断链接本身存在：
+          // existsSync 跟随链接检查目标，对悬空 junction 返回 false → 残留坏
+          // 链接不删除 → 随后 symlinkSync 撞 EEXIST 失败被吞 → 误报全部健康。
+          // 与注入路径 dev_inject_plugin 的写法保持一致。
+          let linkExists = false
+          try { linkExists = lstatSync(linkPath).isSymbolicLink() || lstatSync(linkPath).isDirectory() } catch { /* 不存在 */ }
+          if (linkExists) {
+            try { rmSync(linkPath, { recursive: true, force: true }) } catch { /* 删除失败尝试覆盖 */ }
+          }
           try {
             mkdirSync(linkDir, { recursive: true })
             symlinkSync(target, linkPath, 'junction')


### PR DESCRIPTION
## 背景

Issue #19：`dev_heal_links` 在 `link:` 依赖的 junction 悬空（目标目录被删/改名后）时返回「OK: 全部 link: 依赖 junction 健康（无需修复）」，悬空 junction 不被重建，重启后注入器加载失败且无任何提示——自愈工具静默失效。

## 根因

`healProfileLinks()` 重建分支的删除守卫用 `existsSync(linkPath)`：

- `existsSync` 跟随链接检查目标，对悬空 junction 返回 false → 残留坏链接不删除；
- 随后 `symlinkSync(target, linkPath, 'junction')` 撞 EEXIST 失败，错误被 catch 吞掉 → `healed` 为空数组 → 对外报「全部健康」。

同款问题在注入路径 `dev_inject_plugin`（约 1939–1951 行）已修复（注释明确记录「判断链接存在必须用 lstatSync」），`healProfileLinks` 扩展时漏改。

## 改动

- `src/index.ts`：删除守卫改用 `lstatSync` 判断链接本身存在（与注入路径写法一致）
- `CHANGELOG.md`：新增 Unreleased 条目

## 验证

- 本地复现：悬空 junction 场景下旧代码返回「全部健康」且链接未重建（与 issue 描述一致，self-heal.log 无任何记录）
- 修复后逻辑链路：`isHealthyLink` 检测悬空 → `lstatSync` 确认链接本身存在 → `rmSync` 删除坏链接 → `symlinkSync` 重建到声明目标
- 注意：运行中的实例需重启后加载新代码（`dev_reload_package` 依赖 `--expose-internals`，见 issue #10）

Fixes #19